### PR TITLE
feat(inclusion): verify receipts, transactions, and logs against authenticated roots

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -161,19 +161,45 @@ one snapshot in the `HistoricalSummariesProvider` and looks up the
 relevant index for each request. If your application verifies blocks
 across a wide time range, refresh the snapshot when it falls behind.
 
+## Inclusion verification (v0.2+)
+
+`VerifiedBlock` carries the authenticated `transactions_root` and
+`receipts_root`. The [`inclusion`](../src/inclusion.rs) module turns
+those roots into one-call MPT-proof helpers:
+
+* `verify_transaction_inclusion(tx_index, raw_tx, proof)` — bind
+  wire-format bytes to the authenticated `transactions_root`.
+* `verify_receipt_inclusion(receipt_index, raw_receipt, proof)` — bind
+  to the authenticated `receipts_root`.
+* `verify_and_decode_receipt(...)` — same, plus return a typed
+  `alloy::consensus::ReceiptEnvelope` (handles legacy / EIP-2930 /
+  EIP-1559 / EIP-4844 / EIP-7702 variants).
+
+These are **trie-binding** helpers — they prove `(key, value)` is in a
+trie rooted at the supplied root, with key derived from the index per
+Ethereum's MPT convention (`rlp(index)`). They do not perform any
+independent header verification; the trust comes from the
+`VerifiedBlock` providing an authenticated root.
+
+Implementation delegates to `alloy-trie::proof::verify_proof` (the same
+verifier used by the alloy / reth ecosystem). The
+`root_matches_alloy_canonical_receipt_root` integration test confirms
+the trie shape we generate matches `alloy::consensus::proofs::calculate_receipt_root`.
+
 ## What this crate explicitly does NOT verify
 
-* **Block bodies.** `VerifiedBlock` holds only the header. If you need
-  to verify transactions or receipts, use the `transactions_root` /
-  `receipts_root` from the verified header as a trust anchor and run an
-  MPT proof against the body bytes you fetch separately.
 * **State roots.** `header.state_root` is authenticated, but resolving
   individual storage slots requires additional MPT proofs out of scope
-  here.
+  here. (Could land in v0.3 — same pattern as receipt inclusion, but
+  against the state trie which is significantly more complex.)
 * **Reorgs.** This crate authenticates that a block was *at some point*
   canonical (per the embedded accumulator or current beacon state). It
   does not detect reorgs against your local view; that's a chain-tip
   concern handled by tools like Helios.
+* **MPT proof generation.** Callers supply the proof — `eth-historian`
+  only verifies it. Most archive nodes can produce receipt/tx proofs;
+  for self-generated proofs, use `alloy-trie::HashBuilder` against the
+  full block body.
 
 ## References
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,6 +976,7 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "alloy-rlp",
+ "alloy-trie",
  "anyhow",
  "async-trait",
  "ethereum_hashing",
@@ -1847,7 +1848,9 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
 dependencies = [
+ "alloy-rlp",
  "cfg-if",
+ "proptest",
  "ruint",
  "serde",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ rust-version = "1.85"
 # `portal_types::execution::ssz_header` (RLP-in-SSZ codec).
 alloy = { version = ">=1.1, <1.6", default-features = false, features = ["consensus", "eips", "rlp", "serde"] }
 alloy-rlp = "0.3"
+# MPT proof verification — used by `inclusion` module to verify receipts /
+# transactions against the authenticated roots in `VerifiedBlock`.
+alloy-trie = "0.9"
 
 # SSZ + tree hashing — same versions trin uses.
 ethereum_ssz = "0.9"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # eth-historian
 
-> Trustless cryptographic authentication of historical Ethereum execution-layer blocks for off-chain consumers.
+> Trustless cryptographic authentication of historical Ethereum execution-layer blocks — and the receipts, transactions, and logs inside them — for off-chain consumers.
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](#license)
 
-Off-chain indexers, data pipelines, and AI agents that read historical Ethereum blocks have been stuck choosing between (a) trusting an archive RPC, (b) running their own archive node (terabytes), or (c) trusting an indexer's reputation/slashing. **eth-historian** is a fourth option: feed it raw block data from any source, get back a header that's been cryptographically verified against canonized commitments.
+Off-chain indexers, data pipelines, and AI agents that read historical Ethereum blocks have been stuck choosing between (a) trusting an archive RPC, (b) running their own archive node (terabytes), or (c) trusting an indexer's reputation/slashing. **eth-historian** is a fourth option: feed it raw block data from any source, get back a header that's been cryptographically verified against canonized commitments — then verify any specific receipt, transaction, or event log inside that block via Merkle Patricia Trie proofs against the authenticated roots.
 
 ## Why this exists
 
@@ -39,6 +39,13 @@ let verifier = Verifier::builder()
 let block = verifier.verify_block_by_number(10_000_835).await?;
 println!("state root: {:?}", block.header.state_root);
 println!("verified via: {:?}", block.auth_path);  // HistoricalHashes
+
+// Once authenticated, verify a specific receipt is in this block:
+// `raw_receipt` is wire-format bytes; `proof_nodes` is the MPT path
+// (both supplied by the caller, e.g. fetched alongside the receipt).
+block.verify_receipt_inclusion(receipt_index, &raw_receipt, &proof_nodes)?;
+let receipt = block.verify_and_decode_receipt(receipt_index, &raw_receipt, &proof_nodes)?;
+for log in receipt.logs() { /* iterate trustlessly */ }
 ```
 
 ### TypeScript / JavaScript
@@ -66,6 +73,18 @@ from eth_historian import verify_header_with_proof
 verified = await verify_header_with_proof(ssz_bytes)
 print(verified.state_root, 'via', verified.auth_path)
 ```
+
+## Inclusion verification
+
+Once a block is authenticated, its `transactions_root` and `receipts_root` are trustworthy. The [`inclusion`](https://docs.rs/eth-historian/latest/eth_historian/inclusion/) module turns those roots into one-call helpers for:
+
+* **`verify_transaction_inclusion(tx_index, raw_tx, proof)`** — bind the wire-format bytes to the authenticated `transactions_root`.
+* **`verify_receipt_inclusion(receipt_index, raw_receipt, proof)`** — bind a receipt to the authenticated `receipts_root`.
+* **`verify_and_decode_receipt(...)`** — same, plus return a typed [`alloy::consensus::ReceiptEnvelope`] so you can iterate logs trustlessly.
+
+The MPT proofs themselves are caller-supplied. Most Ethereum execution clients can produce them on demand (`debug_traceBlockByNumber`, `eth_getProof` for state, third-party proof services), or you can compute them locally from the full block body using `alloy-trie`.
+
+End result: any off-chain consumer can verify "this event happened on canonical Ethereum at block N" with a `(header, proof)` pair and a single library call — no archive node, no RPC trust, no separate MPT verifier to compose.
 
 ## What's authenticated against what
 
@@ -114,8 +133,9 @@ Post-Capella verification has standard sync-committee light-client trust — no 
 
 ## Status
 
-* **v0.1** (this release): Rust core, TS bindings (wasm-bindgen), Python bindings (PyO3), `ArchiveRpcSource` (pre-merge), `PortalSidecarSource` (all eras).
-* **v0.2** (planned): `Era1FileSource`, post-merge proof construction in `ArchiveRpcSource`, hosted epoch-accumulator data bundle, `Go` and `Swift` bindings if there's pull.
+* **v0.1**: Rust core, TS bindings (wasm-bindgen), Python bindings (PyO3), Go bindings (cgo), `ArchiveRpcSource` (pre-merge), `PortalSidecarSource` (all eras).
+* **v0.2** (this release): `inclusion` module — receipt / transaction / log inclusion verification against authenticated roots.
+* **v0.3** (planned): `Era1FileSource`, post-merge proof construction in `ArchiveRpcSource` (closes the trin-sidecar dependency for full era coverage), hosted epoch-accumulator data bundle, Swift bindings.
 
 ## Prior art
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -57,6 +57,55 @@ impl VerifiedBlock {
     pub fn block_hash(&self) -> alloy::primitives::B256 {
         self.header.hash_slow()
     }
+
+    /// Verify a transaction is in this block at `tx_index`, against the
+    /// authenticated `transactions_root`. See [`crate::inclusion`] for
+    /// the trust model.
+    pub fn verify_transaction_inclusion(
+        &self,
+        tx_index: u64,
+        raw_tx: &[u8],
+        proof_nodes: &[impl AsRef<[u8]>],
+    ) -> Result<()> {
+        crate::inclusion::verify_transaction_inclusion(
+            self.header.transactions_root,
+            tx_index,
+            raw_tx,
+            proof_nodes,
+        )
+    }
+
+    /// Verify a receipt is in this block at `receipt_index`, against the
+    /// authenticated `receipts_root`.
+    pub fn verify_receipt_inclusion(
+        &self,
+        receipt_index: u64,
+        raw_receipt: &[u8],
+        proof_nodes: &[impl AsRef<[u8]>],
+    ) -> Result<()> {
+        crate::inclusion::verify_receipt_inclusion(
+            self.header.receipts_root,
+            receipt_index,
+            raw_receipt,
+            proof_nodes,
+        )
+    }
+
+    /// Verify a receipt's inclusion and decode it into a typed
+    /// [`alloy::consensus::ReceiptEnvelope`].
+    pub fn verify_and_decode_receipt(
+        &self,
+        receipt_index: u64,
+        raw_receipt: &[u8],
+        proof_nodes: &[impl AsRef<[u8]>],
+    ) -> Result<alloy::consensus::ReceiptEnvelope> {
+        crate::inclusion::verify_and_decode_receipt(
+            self.header.receipts_root,
+            receipt_index,
+            raw_receipt,
+            proof_nodes,
+        )
+    }
 }
 
 /// Builder for [`Verifier`]. See module docs for usage.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -40,6 +40,15 @@ pub enum Error {
     #[error("proof-construction error: {0}")]
     ProofConstruction(String),
 
+    #[error("MPT proof verification failed: {0}")]
+    MptInclusion(String),
+
+    #[error("failed to decode receipt at index {index}: {reason}")]
+    ReceiptDecode { index: u64, reason: String },
+
+    #[error("failed to decode transaction at index {index}: {reason}")]
+    TransactionDecode { index: u64, reason: String },
+
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 }

--- a/src/inclusion.rs
+++ b/src/inclusion.rs
@@ -1,0 +1,188 @@
+//! Verify inclusion of transactions, receipts, and logs in an authenticated
+//! Ethereum block via Merkle Patricia Trie proofs.
+//!
+//! Once a block has been authenticated by [`crate::Verifier::verify`], its
+//! `transactions_root` and `receipts_root` are trustworthy. This module
+//! turns them into a usable trust anchor: given an MPT proof, you can
+//! verify a specific transaction or receipt was actually in the block.
+//!
+//! # Trust model
+//!
+//! These helpers do **no** independent header verification — they bind a
+//! `(key, value)` pair to a root you supply. Pair them with a
+//! [`crate::VerifiedBlock`] (whose roots are authenticated via
+//! eth-historian's canonized accumulators / `historical_summaries`) for
+//! end-to-end trustless inclusion proofs.
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! # use eth_historian::{Verifier, sources::ArchiveRpcSource};
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let verifier = Verifier::builder()
+//!     .data_source(ArchiveRpcSource::new("https://eth.llamarpc.com"))
+//!     .build();
+//!
+//! let block = verifier.verify_block_by_number(10_000_835).await?;
+//!
+//! // Caller-supplied: receipt at index 3 in this block, plus its MPT proof.
+//! let raw_receipt: Vec<u8> = fetch_raw_receipt();
+//! let proof_nodes: Vec<Vec<u8>> = fetch_receipt_proof();
+//!
+//! block.verify_receipt_inclusion(3, &raw_receipt, &proof_nodes)?;
+//! # Ok(())
+//! # }
+//! # fn fetch_raw_receipt() -> Vec<u8> { unimplemented!() }
+//! # fn fetch_receipt_proof() -> Vec<Vec<u8>> { unimplemented!() }
+//! ```
+
+use alloy::consensus::ReceiptEnvelope;
+use alloy::eips::eip2718::Decodable2718;
+use alloy::primitives::{Bytes, B256};
+use alloy_rlp::{Decodable, Encodable};
+use alloy_trie::{proof::verify_proof, Nibbles};
+
+use crate::errors::{Error, Result};
+
+/// Verify a Merkle Patricia Trie proof that `value` is stored at `key`
+/// under a trie whose root is `root`.
+///
+/// Low-level — most callers should use [`verify_transaction_inclusion`],
+/// [`verify_receipt_inclusion`], or the convenience methods on
+/// [`crate::VerifiedBlock`].
+///
+/// `key` is the raw key bytes (e.g. `rlp(tx_index)`); they're unpacked
+/// into nibbles internally. `proof_nodes` is the ordered list of
+/// RLP-encoded trie nodes from the root down to the leaf.
+pub fn verify_mpt_inclusion(
+    root: B256,
+    key: &[u8],
+    value: &[u8],
+    proof_nodes: &[impl AsRef<[u8]>],
+) -> Result<()> {
+    if proof_nodes.is_empty() {
+        return Err(Error::MptInclusion("empty proof".into()));
+    }
+
+    let nibbles = Nibbles::unpack(key);
+    let proof_bytes: Vec<Bytes> = proof_nodes
+        .iter()
+        .map(|n| Bytes::copy_from_slice(n.as_ref()))
+        .collect();
+
+    verify_proof(root, nibbles, Some(value.to_vec()), proof_bytes.iter())
+        .map_err(|e| Error::MptInclusion(e.to_string()))
+}
+
+/// Verify a transaction is in a block at the given index, against an
+/// authenticated `transactions_root`.
+///
+/// `raw_tx` is the EIP-2718 wire-format bytes (legacy transactions are
+/// just RLP; typed transactions have a 1-byte type prefix). They are
+/// compared as-is to the trie value — this function does not decode the
+/// transaction, that's a separate concern.
+pub fn verify_transaction_inclusion(
+    transactions_root: B256,
+    tx_index: u64,
+    raw_tx: &[u8],
+    proof_nodes: &[impl AsRef<[u8]>],
+) -> Result<()> {
+    let key = rlp_encode_index(tx_index);
+    verify_mpt_inclusion(transactions_root, &key, raw_tx, proof_nodes)
+}
+
+/// Verify a receipt is in a block at the given index, against an
+/// authenticated `receipts_root`.
+///
+/// `raw_receipt` is the value as stored in the receipt trie. For typed
+/// (EIP-2718) receipts that's `tx_type_byte || rlp(receipt)`; for legacy
+/// receipts it's just `rlp(receipt)`.
+pub fn verify_receipt_inclusion(
+    receipts_root: B256,
+    receipt_index: u64,
+    raw_receipt: &[u8],
+    proof_nodes: &[impl AsRef<[u8]>],
+) -> Result<()> {
+    let key = rlp_encode_index(receipt_index);
+    verify_mpt_inclusion(receipts_root, &key, raw_receipt, proof_nodes)
+}
+
+/// Verify a receipt's inclusion and decode it into a typed
+/// [`ReceiptEnvelope`] (handling legacy / EIP-2930 / EIP-1559 / EIP-4844
+/// / EIP-7702 variants).
+pub fn verify_and_decode_receipt(
+    receipts_root: B256,
+    receipt_index: u64,
+    raw_receipt: &[u8],
+    proof_nodes: &[impl AsRef<[u8]>],
+) -> Result<ReceiptEnvelope> {
+    verify_receipt_inclusion(receipts_root, receipt_index, raw_receipt, proof_nodes)?;
+    decode_receipt(receipt_index, raw_receipt)
+}
+
+/// Decode a wire-format receipt (handles both legacy and EIP-2718 typed).
+pub fn decode_receipt(receipt_index: u64, raw_receipt: &[u8]) -> Result<ReceiptEnvelope> {
+    if raw_receipt.is_empty() {
+        return Err(Error::ReceiptDecode {
+            index: receipt_index,
+            reason: "empty receipt bytes".into(),
+        });
+    }
+
+    // EIP-2718: typed receipts start with a single-byte type tag in 0x00..0x7f.
+    // Legacy receipts start with an RLP list header (0xc0..0xff).
+    let mut buf: &[u8] = raw_receipt;
+    if raw_receipt[0] >= 0x80 {
+        // Legacy. ReceiptEnvelope::decode handles plain RLP.
+        ReceiptEnvelope::decode(&mut buf).map_err(|e| Error::ReceiptDecode {
+            index: receipt_index,
+            reason: e.to_string(),
+        })
+    } else {
+        // Typed. Decode2718 expects the type byte + payload.
+        ReceiptEnvelope::decode_2718(&mut buf).map_err(|e| Error::ReceiptDecode {
+            index: receipt_index,
+            reason: e.to_string(),
+        })
+    }
+}
+
+// Ethereum trie keys for the transaction/receipt tries are RLP-encoded
+// integer indexes (`rlp(tx_index)`). alloy-rlp's `Encodable` for `u64`
+// produces the canonical RLP of a non-negative integer.
+fn rlp_encode_index(index: u64) -> Vec<u8> {
+    let mut out = Vec::new();
+    index.encode(&mut out);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_proof_rejected() {
+        let root = B256::ZERO;
+        let key = rlp_encode_index(0);
+        let value = b"anything";
+        let proof: Vec<Vec<u8>> = Vec::new();
+        let err = verify_mpt_inclusion(root, &key, value, &proof).unwrap_err();
+        assert!(matches!(err, Error::MptInclusion(_)));
+    }
+
+    #[test]
+    fn rlp_encode_index_matches_alloy() {
+        // Sanity: `rlp(0)` is `0x80` (empty string), `rlp(1)` is `0x01`.
+        // These are canonical Ethereum trie keys for the first two indices.
+        assert_eq!(rlp_encode_index(0), vec![0x80]);
+        assert_eq!(rlp_encode_index(1), vec![0x01]);
+        assert_eq!(rlp_encode_index(127), vec![0x7f]);
+        assert_eq!(rlp_encode_index(128), vec![0x81, 0x80]);
+    }
+
+    #[test]
+    fn decode_receipt_rejects_empty() {
+        let err = decode_receipt(0, &[]).unwrap_err();
+        assert!(matches!(err, Error::ReceiptDecode { index: 0, .. }));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ pub mod errors;
 pub mod header_validator;
 pub mod historical_roots_acc;
 pub mod historical_summaries_provider;
+pub mod inclusion;
 pub mod merkle;
 pub mod portal_types;
 pub mod proof_construction;

--- a/tests/inclusion.rs
+++ b/tests/inclusion.rs
@@ -1,0 +1,311 @@
+//! Integration tests for receipt / transaction inclusion verification.
+//!
+//! These build small but real Merkle Patricia Tries via `alloy-trie`,
+//! generate proofs against them, and then verify those proofs through
+//! eth-historian's public API. A passing test here means the verifier
+//! agrees with `alloy-trie`'s hashing — i.e. it accepts proofs that
+//! match real Ethereum trie roots and rejects tampered ones.
+//!
+//! Why synthetic-but-real: the Ethereum receipt/tx tries use the same
+//! Yellow Paper MPT as state, so a roundtrip on hand-built data
+//! exercises the same code path that runs on production data. The unit
+//! we're testing is `verify_mpt_inclusion` plus its `tx`/`receipt`
+//! wrappers; the trie semantics live in alloy-trie, which is
+//! independently tested by the alloy ecosystem.
+
+use alloy::consensus::{Header, Receipt, ReceiptEnvelope, ReceiptWithBloom};
+use alloy::primitives::{Bloom, Bytes, B256};
+use alloy_rlp::Encodable;
+use alloy_trie::{hash_builder::HashBuilder, proof::ProofRetainer, Nibbles};
+use eth_historian::{
+    inclusion::{
+        decode_receipt, verify_and_decode_receipt, verify_mpt_inclusion, verify_receipt_inclusion,
+        verify_transaction_inclusion,
+    },
+    AuthPath, VerifiedBlock,
+};
+
+/// Build a minimal MPT over `pairs` (treated as `(rlp(index), value)` pairs)
+/// and return `(root, proof_nodes_for_target)`. Pairs are sorted by trie key
+/// internally — caller supplies them in any order.
+fn build_trie_with_proof(pairs: &[(u64, Vec<u8>)], target_index: u64) -> (B256, Vec<Bytes>) {
+    let mut keyed: Vec<(Vec<u8>, Vec<u8>)> = pairs
+        .iter()
+        .map(|(idx, value)| {
+            let mut key = Vec::new();
+            idx.encode(&mut key);
+            (key, value.clone())
+        })
+        .collect();
+    keyed.sort_by(|a, b| Nibbles::unpack(&a.0).cmp(&Nibbles::unpack(&b.0)));
+
+    let mut target_key = Vec::new();
+    target_index.encode(&mut target_key);
+    let target_nibbles = Nibbles::unpack(&target_key);
+
+    let retainer = ProofRetainer::new(vec![target_nibbles]);
+    let mut hb = HashBuilder::default().with_proof_retainer(retainer);
+
+    for (key, value) in &keyed {
+        hb.add_leaf(Nibbles::unpack(key), value);
+    }
+
+    let root = hb.root();
+    let proof_nodes = hb.take_proof_nodes();
+
+    // Canonical alloy-trie pattern: hand the verifier the full sorted node
+    // list. `matching_nodes_sorted` looks tempting but drops nodes that
+    // verify_proof needs when small leaves are encoded inline in their
+    // parent branch (Yellow Paper Appendix D).
+    let nodes: Vec<Bytes> = proof_nodes
+        .into_nodes_sorted()
+        .into_iter()
+        .map(|(_, bytes)| bytes)
+        .collect();
+    (root, nodes)
+}
+
+fn synthetic_receipt(status: bool, gas_used: u64) -> ReceiptEnvelope {
+    ReceiptEnvelope::Legacy(ReceiptWithBloom {
+        receipt: Receipt {
+            status: status.into(),
+            cumulative_gas_used: gas_used,
+            logs: Vec::new(),
+        },
+        logs_bloom: Bloom::ZERO,
+    })
+}
+
+fn encode_envelope_for_trie(env: &ReceiptEnvelope) -> Vec<u8> {
+    use alloy::eips::eip2718::Encodable2718;
+    // Trie value for typed receipts is `tx_type || rlp(receipt)`; for
+    // legacy it's just `rlp(receipt)`. Encodable2718::encoded_2718
+    // produces exactly this wire format.
+    env.encoded_2718()
+}
+
+#[test]
+fn verify_receipt_inclusion_roundtrip() {
+    // Three legacy receipts at indices 0, 1, 2.
+    let receipts = [
+        encode_envelope_for_trie(&synthetic_receipt(true, 21_000)),
+        encode_envelope_for_trie(&synthetic_receipt(true, 42_000)),
+        encode_envelope_for_trie(&synthetic_receipt(false, 100_000)),
+    ];
+    let pairs: Vec<(u64, Vec<u8>)> = receipts
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(i, b)| (i as u64, b))
+        .collect();
+
+    for target in 0u64..3 {
+        let (root, proof) = build_trie_with_proof(&pairs, target);
+        verify_receipt_inclusion(root, target, &receipts[target as usize], &proof)
+            .expect("legitimate proof should verify");
+    }
+}
+
+#[test]
+fn verify_receipt_inclusion_rejects_wrong_value() {
+    let r0 = encode_envelope_for_trie(&synthetic_receipt(true, 21_000));
+    let r1 = encode_envelope_for_trie(&synthetic_receipt(true, 42_000));
+    let pairs = vec![(0u64, r0.clone()), (1u64, r1.clone())];
+
+    let (root, proof) = build_trie_with_proof(&pairs, 0);
+
+    // Tamper with the value bytes.
+    let mut wrong = r0.clone();
+    *wrong.last_mut().unwrap() ^= 0x01;
+
+    let err = verify_receipt_inclusion(root, 0, &wrong, &proof).unwrap_err();
+    assert!(
+        matches!(err, eth_historian::Error::MptInclusion(_)),
+        "expected MptInclusion error, got {err:?}"
+    );
+}
+
+#[test]
+fn verify_receipt_inclusion_rejects_wrong_root() {
+    let r0 = encode_envelope_for_trie(&synthetic_receipt(true, 21_000));
+    let r1 = encode_envelope_for_trie(&synthetic_receipt(true, 42_000));
+    let pairs = vec![(0u64, r0.clone()), (1u64, r1.clone())];
+    let (_root, proof) = build_trie_with_proof(&pairs, 0);
+
+    // Use a totally different root.
+    let bad_root = B256::repeat_byte(0xff);
+    let err = verify_receipt_inclusion(bad_root, 0, &r0, &proof).unwrap_err();
+    assert!(matches!(err, eth_historian::Error::MptInclusion(_)));
+}
+
+#[test]
+fn verify_receipt_inclusion_rejects_wrong_index() {
+    let r0 = encode_envelope_for_trie(&synthetic_receipt(true, 21_000));
+    let r1 = encode_envelope_for_trie(&synthetic_receipt(true, 42_000));
+    let pairs = vec![(0u64, r0.clone()), (1u64, r1.clone())];
+    let (root, proof) = build_trie_with_proof(&pairs, 0);
+
+    // Proof is for index 0, but we claim it's for index 1.
+    let err = verify_receipt_inclusion(root, 1, &r0, &proof).unwrap_err();
+    assert!(matches!(err, eth_historian::Error::MptInclusion(_)));
+}
+
+#[test]
+fn verify_transaction_inclusion_roundtrip() {
+    // Use opaque payloads — the inclusion verifier doesn't decode them.
+    let txs = [
+        b"transaction-zero-payload-bytes".to_vec(),
+        b"transaction-one-payload-bytes".to_vec(),
+        b"transaction-two-payload-bytes".to_vec(),
+    ];
+    let pairs: Vec<(u64, Vec<u8>)> = txs
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(i, b)| (i as u64, b))
+        .collect();
+
+    for target in 0u64..3 {
+        let (root, proof) = build_trie_with_proof(&pairs, target);
+        verify_transaction_inclusion(root, target, &txs[target as usize], &proof)
+            .expect("legitimate tx proof should verify");
+    }
+}
+
+#[test]
+fn verify_and_decode_receipt_returns_typed_envelope() {
+    let r0 = synthetic_receipt(true, 21_000);
+    let r0_bytes = encode_envelope_for_trie(&r0);
+    let pairs = vec![(0u64, r0_bytes.clone())];
+    let (root, proof) = build_trie_with_proof(&pairs, 0);
+
+    let decoded = verify_and_decode_receipt(root, 0, &r0_bytes, &proof)
+        .expect("verify+decode should succeed");
+
+    match decoded {
+        ReceiptEnvelope::Legacy(r) => {
+            assert_eq!(r.receipt.cumulative_gas_used, 21_000);
+            assert!(r.receipt.status.coerce_status());
+            assert_eq!(r.receipt.logs.len(), 0);
+        }
+        other => panic!("expected Legacy receipt, got {:?}", other),
+    }
+}
+
+#[test]
+fn decode_receipt_handles_legacy_and_typed() {
+    let legacy = synthetic_receipt(true, 21_000);
+    let legacy_bytes = encode_envelope_for_trie(&legacy);
+    assert!(
+        legacy_bytes[0] >= 0x80,
+        "legacy receipt RLP starts with list header"
+    );
+    decode_receipt(0, &legacy_bytes).expect("legacy decode");
+
+    // Typed receipts (EIP-2930+) are `type_byte || rlp_payload`.
+    // We don't have a synthetic constructor handy for typed receipts in
+    // this test scope; verify_and_decode_receipt above exercises the
+    // legacy path, and decode_receipt's typed branch is exercised by
+    // real-Ethereum data tests added once fixtures land.
+}
+
+#[test]
+fn verifiedblock_method_uses_authenticated_root() {
+    // Construct a VerifiedBlock with our trie root manually pinned in
+    // the header. This exercises the `VerifiedBlock::*_inclusion`
+    // methods exactly the same as a real verifier would after
+    // authenticating the header.
+    let r0 = encode_envelope_for_trie(&synthetic_receipt(true, 21_000));
+    let r1 = encode_envelope_for_trie(&synthetic_receipt(true, 42_000));
+    let pairs = vec![(0u64, r0.clone()), (1u64, r1.clone())];
+    let (receipts_root, receipt_proof) = build_trie_with_proof(&pairs, 0);
+
+    // Realistic-sized synthetic transaction payloads (>32 bytes each so
+    // the leaves are stored as hash refs, not inlined).
+    let tx0 = vec![0xaau8; 64];
+    let tx1 = vec![0xbbu8; 64];
+    let txs: Vec<(u64, Vec<u8>)> = vec![(0u64, tx0.clone()), (1u64, tx1.clone())];
+    let (transactions_root, tx_proof) = build_trie_with_proof(&txs, 1);
+
+    let header = Header {
+        receipts_root,
+        transactions_root,
+        ..Default::default()
+    };
+    let block = VerifiedBlock {
+        header,
+        auth_path: AuthPath::HistoricalHashes,
+    };
+
+    block
+        .verify_receipt_inclusion(0, &r0, &receipt_proof)
+        .expect("receipt inclusion via VerifiedBlock");
+    block
+        .verify_transaction_inclusion(1, &tx1, &tx_proof)
+        .expect("tx inclusion via VerifiedBlock");
+
+    let decoded = block
+        .verify_and_decode_receipt(0, &r0, &receipt_proof)
+        .expect("decode via VerifiedBlock");
+    assert!(matches!(decoded, ReceiptEnvelope::Legacy(_)));
+}
+
+#[test]
+fn verify_mpt_inclusion_low_level_roundtrip() {
+    // Realistic-sized values (>32 bytes) so the leaves are stored as
+    // hash refs in their parent branch — small (<32-byte) values are
+    // inlined and produce a proof shape that real Ethereum tries don't
+    // exhibit (every real receipt is at least ~270 bytes).
+    let pairs = vec![
+        (0u64, vec![0x11u8; 64]),
+        (1u64, vec![0x22u8; 64]),
+        (2u64, vec![0x33u8; 64]),
+    ];
+    let (root, proof) = build_trie_with_proof(&pairs, 1);
+
+    let mut key = Vec::new();
+    1u64.encode(&mut key);
+
+    verify_mpt_inclusion(root, &key, &pairs[1].1, &proof)
+        .expect("low-level verification should succeed");
+}
+
+#[test]
+fn verify_mpt_inclusion_rejects_empty_proof() {
+    let root = B256::ZERO;
+    let key: Vec<u8> = vec![0x80];
+    let value = b"x";
+    let proof: Vec<Bytes> = Vec::new();
+    let err = verify_mpt_inclusion(root, &key, value, &proof).unwrap_err();
+    assert!(matches!(err, eth_historian::Error::MptInclusion(_)));
+}
+
+#[test]
+fn root_matches_alloy_canonical_receipt_root() {
+    // Sanity: the trie root we generate for a given list of receipts
+    // matches `alloy::consensus::proofs::calculate_receipt_root` — i.e.
+    // we agree with the canonical Ethereum root computation. If this
+    // ever fails, our trust anchor is mis-aligned with the rest of the
+    // ecosystem.
+    use alloy::consensus::proofs::calculate_receipt_root;
+
+    let receipts = vec![
+        synthetic_receipt(true, 21_000),
+        synthetic_receipt(true, 42_000),
+        synthetic_receipt(false, 100_000),
+    ];
+    let alloy_root = calculate_receipt_root(&receipts);
+
+    let pairs: Vec<(u64, Vec<u8>)> = receipts
+        .iter()
+        .map(encode_envelope_for_trie)
+        .enumerate()
+        .map(|(i, b)| (i as u64, b))
+        .collect();
+    let (our_root, _) = build_trie_with_proof(&pairs, 0);
+
+    assert_eq!(
+        our_root, alloy_root,
+        "our trie root must match the canonical Ethereum receipt root"
+    );
+}


### PR DESCRIPTION
## Summary

Adds an `inclusion` module that turns a `VerifiedBlock`'s authenticated `transactions_root` / `receipts_root` into one-call MPT-proof helpers — so off-chain consumers can verify *what's inside* a block, not just the block header.

* `verify_transaction_inclusion(tx_index, raw_tx, proof)`
* `verify_receipt_inclusion(receipt_index, raw_receipt, proof)`
* `verify_and_decode_receipt(...)` returning a typed `alloy::consensus::ReceiptEnvelope` (handles legacy / EIP-2930 / EIP-1559 / EIP-4844 / EIP-7702)
* Same three as `VerifiedBlock::*` methods for ergonomics

Trie semantics delegate to `alloy-trie::proof::verify_proof`. A canonical-root sanity test confirms the trie shape we generate matches `alloy::consensus::proofs::calculate_receipt_root`.

## Why this matters (v0.2 framing)

eth-historian v0.1 stops at the header. Off-chain consumers still need to compose their own MPT verifier to prove "this specific receipt is in the authenticated block." This PR closes that loop — any consumer (indexer, AI agent, compliance pipeline) can prove an event happened on canonical Ethereum at block N with a single library call.

## Test plan

- [x] `cargo test` — 47 passing (was 36)
  - 15 unit (lib)
  - 11 new integration tests (`tests/inclusion.rs`) covering: roundtrip for receipts/transactions, tampered-value/root/index rejection, receipt decode round-trip, `VerifiedBlock` method coverage, low-level helper, empty-proof rejection, canonical-root sanity check
  - 19 existing integration tests
  - 2 doc tests
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --lib --tests` clean

## Findings worth noting

- `alloy-trie::HashBuilder::take_proof_nodes()` produces redundant proof nodes for sub-32-byte inline-encoded leaves (Yellow Paper Appendix D). Doesn't matter for real Ethereum (every receipt is ≥270 bytes from logs_bloom alone), but tests had to use ≥32-byte values to dodge the edge case.

## Follow-ups (filed as separate work items)

- Expose inclusion verification in FFI bindings (TS / Python / Go)
- Migrate Willow's `crates/network/mpt_verification.rs` to call this module instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)