### PR TITLE
feat(bindings): expose inclusion verification in TS / Python / Go

### DIFF
--- a/bindings/go/Cargo.toml
+++ b/bindings/go/Cargo.toml
@@ -14,5 +14,8 @@ crate-type = ["staticlib", "cdylib"]
 [dependencies]
 eth-historian = { path = "../..", default-features = false }
 ssz = { package = "ethereum_ssz", version = "0.9" }
+# Direct alloy-primitives dep so the FFI shim can construct `B256` from
+# raw bytes. Same rationale as the wasm + Python bindings.
+alloy-primitives = "1"
 hex = "0.4"
 tokio = { version = "1", features = ["rt", "sync"] }

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -55,6 +55,29 @@ func main() {
 }
 ```
 
+### Inclusion verification (v0.2)
+
+Once a block is authenticated, prove specific receipts or transactions are inside it via MPT proofs against the verified roots:
+
+```go
+verified, err := eth_historian.VerifyHeaderWithProof(sszBytes)
+if err != nil { log.Fatal(err) }
+
+// Receipt inclusion: rawReceipt is wire-format (legacy: RLP; typed: type-byte || RLP).
+// proofNodes is the MPT path as [][]byte.
+receiptsRoot, _ := hex.DecodeString(strings.TrimPrefix(verified.ReceiptsRoot, "0x"))
+err = eth_historian.VerifyReceiptInclusion(receiptsRoot, receiptIndex, rawReceipt, proofNodes)
+if err != nil {
+    log.Fatalf("receipt inclusion failed: %v", err)
+}
+
+// Transaction inclusion against the same authenticated block:
+txRoot, _ := hex.DecodeString(strings.TrimPrefix(verified.TransactionsRoot, "0x"))
+err = eth_historian.VerifyTransactionInclusion(txRoot, txIndex, rawTx, txProofNodes)
+```
+
+Both functions return a non-nil error on verification failure with the underlying Rust message. Caller is responsible for fetching the proof nodes (any archive node can produce them via `debug_traceBlockByNumber` / custom proof endpoints).
+
 ## Distribution
 
 The Go module currently builds against a locally-built Rust static library at `target/release/libeth_historian.a`. For pre-built distribution (so users don't need Rust+cargo):

--- a/bindings/go/eth_historian.go
+++ b/bindings/go/eth_historian.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"runtime"
 	"unsafe"
 )
 
@@ -101,6 +102,111 @@ func VerifyHeaderWithProof(bytes []byte) (*VerifiedBlock, error) {
 		ParentHash:       hexEncode(res.parent_hash[:]),
 		AuthPath:         AuthPath(res.auth_path),
 	}, nil
+}
+
+// VerifyTransactionInclusion verifies a transaction is in a block at
+// txIndex, against the authenticated transactionsRoot.
+//
+// transactionsRoot must be 32 bytes. rawTx is wire-format (legacy: RLP;
+// typed: type-byte || RLP). proofNodes is the MPT path from the root
+// down to the leaf. Returns nil on success; non-nil error on failure
+// with the underlying Rust message.
+func VerifyTransactionInclusion(transactionsRoot []byte, txIndex uint64, rawTx []byte, proofNodes [][]byte) error {
+	return runInclusion(
+		transactionsRoot,
+		"transactionsRoot",
+		txIndex,
+		rawTx,
+		proofNodes,
+		func(rootPtr *C.uint8_t, txPtr *C.uint8_t, txLen C.size_t, ptrs **C.uint8_t, lens *C.size_t, n C.size_t) *C.char {
+			return C.eth_historian_verify_transaction_inclusion(
+				rootPtr, C.uint64_t(txIndex), txPtr, txLen, ptrs, lens, n,
+			)
+		},
+	)
+}
+
+// VerifyReceiptInclusion verifies a receipt is in a block at
+// receiptIndex, against the authenticated receiptsRoot.
+//
+// receiptsRoot must be 32 bytes. rawReceipt is wire-format (legacy: RLP;
+// typed: type-byte || RLP). proofNodes is the MPT path from the root
+// down to the leaf. Returns nil on success; non-nil error on failure.
+func VerifyReceiptInclusion(receiptsRoot []byte, receiptIndex uint64, rawReceipt []byte, proofNodes [][]byte) error {
+	return runInclusion(
+		receiptsRoot,
+		"receiptsRoot",
+		receiptIndex,
+		rawReceipt,
+		proofNodes,
+		func(rootPtr *C.uint8_t, valPtr *C.uint8_t, valLen C.size_t, ptrs **C.uint8_t, lens *C.size_t, n C.size_t) *C.char {
+			return C.eth_historian_verify_receipt_inclusion(
+				rootPtr, C.uint64_t(receiptIndex), valPtr, valLen, ptrs, lens, n,
+			)
+		},
+	)
+}
+
+// runInclusion handles the cgo bookkeeping common to both inclusion
+// helpers: argument validation, marshalling proof nodes into parallel
+// C arrays, calling the inclusion FFI, and translating the C-string
+// error path into Go's error type.
+func runInclusion(
+	root []byte,
+	rootField string,
+	_ uint64,
+	rawValue []byte,
+	proofNodes [][]byte,
+	call func(rootPtr *C.uint8_t, valPtr *C.uint8_t, valLen C.size_t, ptrs **C.uint8_t, lens *C.size_t, n C.size_t) *C.char,
+) error {
+	if len(root) != 32 {
+		return fmt.Errorf("eth-historian: %s must be 32 bytes, got %d", rootField, len(root))
+	}
+
+	var rootPtr *C.uint8_t
+	rootPtr = (*C.uint8_t)(unsafe.Pointer(&root[0]))
+
+	var valPtr *C.uint8_t
+	if len(rawValue) > 0 {
+		valPtr = (*C.uint8_t)(unsafe.Pointer(&rawValue[0]))
+	}
+
+	// Marshal `proofNodes` into a parallel ptr+len array. Pinning the
+	// underlying slice headers via the local `ptrs`/`lens` slices keeps
+	// the Go GC from moving them while the C call runs.
+	n := len(proofNodes)
+	ptrs := make([]*C.uint8_t, n)
+	lens := make([]C.size_t, n)
+	for i, node := range proofNodes {
+		if len(node) > 0 {
+			ptrs[i] = (*C.uint8_t)(unsafe.Pointer(&node[0]))
+		}
+		lens[i] = C.size_t(len(node))
+	}
+
+	var ptrsPtr **C.uint8_t
+	var lensPtr *C.size_t
+	if n > 0 {
+		ptrsPtr = (**C.uint8_t)(unsafe.Pointer(&ptrs[0]))
+		lensPtr = (*C.size_t)(unsafe.Pointer(&lens[0]))
+	}
+
+	cerr := call(rootPtr, valPtr, C.size_t(len(rawValue)), ptrsPtr, lensPtr, C.size_t(n))
+	// Pin proofNodes / rawValue / root through the call (KeepAlive is
+	// the cgo idiom; the variables are unused after this point but
+	// must outlive the FFI call).
+	runtime.KeepAlive(root)
+	runtime.KeepAlive(rawValue)
+	runtime.KeepAlive(proofNodes)
+	runtime.KeepAlive(ptrs)
+	runtime.KeepAlive(lens)
+
+	if cerr == nil {
+		return nil
+	}
+	msg := C.GoString(cerr)
+	C.eth_historian_free_error(cerr)
+	return errors.New(msg)
 }
 
 // CanonizedFingerprints returns the SHA-256 fingerprints of the embedded

--- a/bindings/go/eth_historian_test.go
+++ b/bindings/go/eth_historian_test.go
@@ -101,3 +101,34 @@ func TestAuthPath_String(t *testing.T) {
 		}
 	}
 }
+
+func TestVerifyTransactionInclusion_RejectsWrongRootLength(t *testing.T) {
+	err := VerifyTransactionInclusion([]byte{0x01, 0x02}, 0, []byte("tx"), nil)
+	if err == nil {
+		t.Fatal("expected error for non-32-byte root")
+	}
+	if !strings.Contains(err.Error(), "must be 32 bytes") {
+		t.Errorf("expected 'must be 32 bytes' message, got: %v", err)
+	}
+}
+
+func TestVerifyReceiptInclusion_RejectsWrongRootLength(t *testing.T) {
+	err := VerifyReceiptInclusion(make([]byte, 31), 0, []byte("r"), nil)
+	if err == nil {
+		t.Fatal("expected error for non-32-byte root")
+	}
+	if !strings.Contains(err.Error(), "must be 32 bytes") {
+		t.Errorf("expected 'must be 32 bytes' message, got: %v", err)
+	}
+}
+
+func TestVerifyTransactionInclusion_EmptyProofRejected(t *testing.T) {
+	// 32-byte root is structurally valid; Rust core rejects the
+	// empty-proof path with `MptInclusion`. This proves the FFI surface
+	// correctly forwards calls into the verifier.
+	root := make([]byte, 32)
+	err := VerifyTransactionInclusion(root, 0, []byte("tx"), nil)
+	if err == nil {
+		t.Fatal("expected MPT verification failure for empty proof")
+	}
+}

--- a/bindings/go/include/eth_historian.h
+++ b/bindings/go/include/eth_historian.h
@@ -41,6 +41,35 @@ EthHistorianVerifyResult eth_historian_verify_header_with_proof(
 
 void eth_historian_free_error(char* error);
 
+/*
+ * Inclusion verification (v0.2). Both functions return NULL on success;
+ * on failure they return a malloc'd C string the caller MUST free via
+ * eth_historian_free_error().
+ *
+ * `proof_node_ptrs` and `proof_node_lens` are parallel arrays of length
+ * `num_proof_nodes`: the i-th proof node is `proof_node_ptrs[i]` of
+ * length `proof_node_lens[i]` bytes.
+ */
+char* eth_historian_verify_transaction_inclusion(
+    const uint8_t*       transactions_root,   /* 32 bytes */
+    uint64_t             tx_index,
+    const uint8_t*       raw_tx,
+    size_t               raw_tx_len,
+    const uint8_t* const* proof_node_ptrs,
+    const size_t*        proof_node_lens,
+    size_t               num_proof_nodes
+);
+
+char* eth_historian_verify_receipt_inclusion(
+    const uint8_t*       receipts_root,       /* 32 bytes */
+    uint64_t             receipt_index,
+    const uint8_t*       raw_receipt,
+    size_t               raw_receipt_len,
+    const uint8_t* const* proof_node_ptrs,
+    const size_t*        proof_node_lens,
+    size_t               num_proof_nodes
+);
+
 void eth_historian_canonized_fingerprints(
     uint8_t merge_macc_sha256_out[32],
     uint8_t historical_roots_sha256_out[32]

--- a/bindings/go/src/lib.rs
+++ b/bindings/go/src/lib.rs
@@ -159,6 +159,140 @@ pub unsafe extern "C" fn eth_historian_free_error(error: *mut c_char) {
     }
 }
 
+/// Build a `Vec<&[u8]>` view over a C array of (ptr, len) pairs.
+///
+/// # Safety
+///
+/// All pointers in `node_ptrs[0..num_nodes]` must be valid for at least
+/// `node_lens[i]` bytes, or null with len 0.
+unsafe fn proof_node_slices<'a>(
+    node_ptrs: *const *const u8,
+    node_lens: *const usize,
+    num_nodes: usize,
+) -> Result<Vec<&'a [u8]>, &'static str> {
+    if num_nodes == 0 {
+        return Ok(Vec::new());
+    }
+    if node_ptrs.is_null() || node_lens.is_null() {
+        return Err("null proof-nodes ptr/len array");
+    }
+    let ptrs = std::slice::from_raw_parts(node_ptrs, num_nodes);
+    let lens = std::slice::from_raw_parts(node_lens, num_nodes);
+    let mut out = Vec::with_capacity(num_nodes);
+    for (i, (p, l)) in ptrs.iter().zip(lens.iter()).enumerate() {
+        if *l == 0 {
+            out.push(&[][..]);
+        } else if p.is_null() {
+            return Err("null proof-node pointer with non-zero len");
+        } else {
+            // Lifetime is bound to the caller's borrow window; we hand
+            // these slices straight into eth_historian::inclusion which
+            // doesn't store them past the call.
+            let _ = i;
+            out.push(std::slice::from_raw_parts(*p, *l));
+        }
+    }
+    Ok(out)
+}
+
+unsafe fn read_root(ptr: *const u8) -> Result<alloy_primitives::B256, &'static str> {
+    if ptr.is_null() {
+        return Err("null root pointer");
+    }
+    let bytes = std::slice::from_raw_parts(ptr, 32);
+    Ok(alloy_primitives::B256::from_slice(bytes))
+}
+
+fn err_cstring(msg: String) -> *mut c_char {
+    CString::new(msg)
+        .unwrap_or_else(|_| CString::new("internal: unencodable error message").unwrap())
+        .into_raw()
+}
+
+/// Verify a transaction is in a block at `tx_index`, against the
+/// authenticated `transactions_root` (32 bytes).
+///
+/// Returns null on success; on failure returns a Rust-allocated C
+/// string the caller MUST free via `eth_historian_free_error`.
+///
+/// # Safety
+///
+/// * `transactions_root` must point to 32 readable bytes.
+/// * `raw_tx` must point to `raw_tx_len` readable bytes (or be null with len 0).
+/// * `proof_node_ptrs` / `proof_node_lens` are arrays of length
+///   `num_proof_nodes` with parallel lifetimes; each `proof_node_ptrs[i]`
+///   must be readable for `proof_node_lens[i]` bytes.
+#[no_mangle]
+pub unsafe extern "C" fn eth_historian_verify_transaction_inclusion(
+    transactions_root: *const u8,
+    tx_index: u64,
+    raw_tx: *const u8,
+    raw_tx_len: usize,
+    proof_node_ptrs: *const *const u8,
+    proof_node_lens: *const usize,
+    num_proof_nodes: usize,
+) -> *mut c_char {
+    let root = match read_root(transactions_root) {
+        Ok(r) => r,
+        Err(e) => return err_cstring(e.into()),
+    };
+    let raw = if raw_tx_len == 0 {
+        &[][..]
+    } else if raw_tx.is_null() {
+        return err_cstring("null raw_tx pointer with non-zero len".into());
+    } else {
+        std::slice::from_raw_parts(raw_tx, raw_tx_len)
+    };
+    let nodes = match proof_node_slices(proof_node_ptrs, proof_node_lens, num_proof_nodes) {
+        Ok(n) => n,
+        Err(e) => return err_cstring(e.into()),
+    };
+    match eth_historian::inclusion::verify_transaction_inclusion(root, tx_index, raw, &nodes) {
+        Ok(()) => ptr::null_mut(),
+        Err(e) => err_cstring(format!("verifyTransactionInclusion: {}", e)),
+    }
+}
+
+/// Verify a receipt is in a block at `receipt_index`, against the
+/// authenticated `receipts_root` (32 bytes).
+///
+/// Returns null on success; on failure returns a Rust-allocated C
+/// string the caller MUST free via `eth_historian_free_error`.
+///
+/// # Safety
+///
+/// Same contract as [`eth_historian_verify_transaction_inclusion`].
+#[no_mangle]
+pub unsafe extern "C" fn eth_historian_verify_receipt_inclusion(
+    receipts_root: *const u8,
+    receipt_index: u64,
+    raw_receipt: *const u8,
+    raw_receipt_len: usize,
+    proof_node_ptrs: *const *const u8,
+    proof_node_lens: *const usize,
+    num_proof_nodes: usize,
+) -> *mut c_char {
+    let root = match read_root(receipts_root) {
+        Ok(r) => r,
+        Err(e) => return err_cstring(e.into()),
+    };
+    let raw = if raw_receipt_len == 0 {
+        &[][..]
+    } else if raw_receipt.is_null() {
+        return err_cstring("null raw_receipt pointer with non-zero len".into());
+    } else {
+        std::slice::from_raw_parts(raw_receipt, raw_receipt_len)
+    };
+    let nodes = match proof_node_slices(proof_node_ptrs, proof_node_lens, num_proof_nodes) {
+        Ok(n) => n,
+        Err(e) => return err_cstring(e.into()),
+    };
+    match eth_historian::inclusion::verify_receipt_inclusion(root, receipt_index, raw, &nodes) {
+        Ok(()) => ptr::null_mut(),
+        Err(e) => err_cstring(format!("verifyReceiptInclusion: {}", e)),
+    }
+}
+
 /// Write the SHA-256 fingerprints of the embedded canonized accumulator
 /// binaries into the two 32-byte caller-provided buffers. Useful for
 /// audit / pinning.

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -673,6 +673,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
@@ -693,6 +703,20 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
@@ -701,7 +725,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
 ]
 
@@ -715,8 +739,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core 0.13.4",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -904,19 +939,24 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "alloy-rlp",
+ "alloy-trie",
  "anyhow",
  "async-trait",
  "ethereum_hashing",
+ "ethereum_serde_utils",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "hex",
  "lazy_static",
  "parking_lot",
+ "rs_merkle",
  "rust-embed",
  "serde",
+ "serde-this-or-that",
  "serde_json",
  "sha2",
  "ssz_types",
+ "superstruct",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -928,6 +968,7 @@ dependencies = [
 name = "eth-historian-py"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "eth-historian",
  "ethereum_ssz",
  "hex",
@@ -1422,7 +1463,9 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
 dependencies = [
+ "alloy-rlp",
  "cfg-if",
+ "proptest",
  "ruint",
  "serde",
  "smallvec",
@@ -1816,6 +1859,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rs_merkle"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb09b49230ba22e8c676e7b75dfe2887dea8121f18b530ae0ba519ce442d2b21"
+dependencies = [
+ "sha2",
+]
+
+[[package]]
 name = "ruint"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2030,6 +2082,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-this-or-that"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90e7ee61f57b2b1a195326bf7ee88651d3d5e688f34bd5971110851764200bf"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2184,6 +2245,12 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -2193,6 +2260,20 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "superstruct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f4e1f478a7728f8855d7e620e9a152cf8932c6614f86564c886f9b8141f3201"
+dependencies = [
+ "darling 0.13.4",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "smallvec",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "syn"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -14,6 +14,9 @@ crate-type = ["cdylib"]
 [dependencies]
 eth-historian = { path = "../..", default-features = false }
 ssz = { package = "ethereum_ssz", version = "0.9" }
+# Direct alloy-primitives dep so the FFI shim can construct `B256` from
+# raw bytes. Same rationale as the wasm + Go bindings.
+alloy-primitives = "1"
 
 pyo3 = { version = "0.24", features = ["extension-module"] }
 tokio = { version = "1", features = ["rt", "sync"] }

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -39,6 +39,32 @@ assert fp["merge_macc_bin_sha256"] == \
     "0xa2368bfa82a89a898b31dca6f37aa287918bd671bd74058912bc440c2288d791"
 ```
 
+### Inclusion verification (v0.2)
+
+Once a block is authenticated, prove specific receipts or transactions are inside it via MPT proofs against the verified roots:
+
+```python
+from eth_historian import (
+    verify_header_with_proof,
+    verify_receipt_inclusion,
+    verify_transaction_inclusion,
+)
+
+verified = verify_header_with_proof(ssz_bytes)
+
+# Receipt inclusion: prove `raw_receipt` is at `receipt_index` under `receipts_root`.
+# `raw_receipt` is wire-format (legacy: RLP; typed: type-byte || RLP).
+# `proof_nodes` is a list of `bytes` — the MPT path from root down.
+receipts_root = bytes.fromhex(verified.receipts_root.removeprefix("0x"))
+verify_receipt_inclusion(receipts_root, receipt_index, raw_receipt, proof_nodes)
+
+# Transaction inclusion against the same authenticated block:
+tx_root = bytes.fromhex(verified.transactions_root.removeprefix("0x"))
+verify_transaction_inclusion(tx_root, tx_index, raw_tx, tx_proof_nodes)
+```
+
+Both functions raise `ValueError` on verification failure with a message describing the mismatch. Caller is responsible for fetching the proof nodes (any archive node can produce them via `debug_traceBlockByNumber` / custom proof endpoints).
+
 ## Build (from source)
 
 ```bash

--- a/bindings/python/src/eth_historian/__init__.py
+++ b/bindings/python/src/eth_historian/__init__.py
@@ -4,14 +4,18 @@ in editable mode (`pip install -e .`)."""
 
 from eth_historian._native import (  # type: ignore[import-not-found]
     VerifiedBlock,
-    verify_header_with_proof,
     canonized_fingerprints,
+    verify_header_with_proof,
+    verify_receipt_inclusion,
+    verify_transaction_inclusion,
     __version__,
 )
 
 __all__ = [
     "VerifiedBlock",
     "verify_header_with_proof",
+    "verify_receipt_inclusion",
+    "verify_transaction_inclusion",
     "canonized_fingerprints",
     "__version__",
 ]

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -89,6 +89,76 @@ fn verify_header_with_proof(py: Python<'_>, bytes: Vec<u8>) -> PyResult<PyVerifi
     })
 }
 
+/// Verify a transaction is in a block at `tx_index`, against the
+/// authenticated `transactions_root` (32 bytes).
+///
+/// `raw_tx` is wire-format bytes (legacy: RLP; typed: type-byte || RLP).
+/// `proof_nodes` is a list of `bytes` — the MPT trie nodes from root
+/// down to the leaf.
+///
+/// Raises `ValueError` on verification failure.
+#[pyfunction]
+fn verify_transaction_inclusion(
+    py: Python<'_>,
+    transactions_root: Vec<u8>,
+    tx_index: u64,
+    raw_tx: Vec<u8>,
+    proof_nodes: Vec<Vec<u8>>,
+) -> PyResult<()> {
+    py.allow_threads(|| {
+        let root = parse_root(&transactions_root, "transactions_root")?;
+        eth_historian::inclusion::verify_transaction_inclusion(
+            root,
+            tx_index,
+            &raw_tx,
+            &proof_nodes,
+        )
+        .map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!("verify_transaction_inclusion: {}", e))
+        })
+    })
+}
+
+/// Verify a receipt is in a block at `receipt_index`, against the
+/// authenticated `receipts_root` (32 bytes).
+///
+/// `raw_receipt` is wire-format bytes (legacy: RLP; typed: type-byte || RLP).
+/// `proof_nodes` is a list of `bytes`.
+///
+/// Raises `ValueError` on verification failure.
+#[pyfunction]
+fn verify_receipt_inclusion(
+    py: Python<'_>,
+    receipts_root: Vec<u8>,
+    receipt_index: u64,
+    raw_receipt: Vec<u8>,
+    proof_nodes: Vec<Vec<u8>>,
+) -> PyResult<()> {
+    py.allow_threads(|| {
+        let root = parse_root(&receipts_root, "receipts_root")?;
+        eth_historian::inclusion::verify_receipt_inclusion(
+            root,
+            receipt_index,
+            &raw_receipt,
+            &proof_nodes,
+        )
+        .map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!("verify_receipt_inclusion: {}", e))
+        })
+    })
+}
+
+fn parse_root(bytes: &[u8], field: &str) -> PyResult<alloy_primitives::B256> {
+    if bytes.len() != 32 {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "{} must be 32 bytes, got {}",
+            field,
+            bytes.len()
+        )));
+    }
+    Ok(alloy_primitives::B256::from_slice(bytes))
+}
+
 /// Returns the SHA-256 fingerprints of the embedded canonized accumulator
 /// binaries as a dict. Useful for clients that want to double-check the
 /// installed wheel ships the constants they expect.
@@ -111,6 +181,8 @@ fn canonized_fingerprints<'py>(py: Python<'py>) -> PyResult<Bound<'py, PyDict>> 
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyVerifiedBlock>()?;
     m.add_function(wrap_pyfunction!(verify_header_with_proof, m)?)?;
+    m.add_function(wrap_pyfunction!(verify_transaction_inclusion, m)?)?;
+    m.add_function(wrap_pyfunction!(verify_receipt_inclusion, m)?)?;
     m.add_function(wrap_pyfunction!(canonized_fingerprints, m)?)?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     Ok(())

--- a/bindings/ts/Cargo.toml
+++ b/bindings/ts/Cargo.toml
@@ -17,6 +17,9 @@ crate-type = ["cdylib", "rlib"]
 eth-historian = { path = "../..", default-features = false }
 
 ssz = { package = "ethereum_ssz", version = "0.9" }
+# Direct alloy-primitives dep so the FFI shim can construct `B256` from
+# raw bytes without going through a higher-level alloy umbrella.
+alloy-primitives = "1"
 
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"

--- a/bindings/ts/README.md
+++ b/bindings/ts/README.md
@@ -35,6 +35,32 @@ console.log(fp.mergeMaccBinSha256);
 //   0xa2368bfa82a89a898b31dca6f37aa287918bd671bd74058912bc440c2288d791
 ```
 
+### Inclusion verification (v0.2)
+
+Once a block is authenticated, prove specific receipts or transactions are inside it via MPT proofs against the verified roots:
+
+```ts
+import {
+  verifyHeaderWithProof,
+  verifyReceiptInclusion,
+  verifyTransactionInclusion,
+} from '@willow-network/eth-historian';
+
+const verified = await verifyHeaderWithProof(sszBytes);
+
+// Receipt inclusion: prove `rawReceipt` is at `receiptIndex` under `receiptsRoot`.
+// `rawReceipt` is wire-format (legacy: RLP; typed: type-byte || RLP).
+// `proofNodes` is the MPT path as `Array<Uint8Array>`.
+const receiptsRoot = hexToBytes(verified.receiptsRoot);  // 32 bytes
+verifyReceiptInclusion(receiptsRoot, BigInt(receiptIndex), rawReceipt, proofNodes);
+
+// Transaction inclusion against the same authenticated block:
+const txRoot = hexToBytes(verified.transactionsRoot);
+verifyTransactionInclusion(txRoot, BigInt(txIndex), rawTx, txProofNodes);
+```
+
+Both functions throw on failure with a message describing the mismatch. Caller is responsible for fetching the proof nodes (any archive node can produce them via `debug_traceBlockByNumber` / custom proof endpoints).
+
 ## Build (from source)
 
 ```bash

--- a/bindings/ts/src/lib.rs
+++ b/bindings/ts/src/lib.rs
@@ -11,8 +11,8 @@
 //! bytes only; it is not trusted to verify them.
 
 use eth_historian::{HeaderWithProof, Verifier};
-use ssz::Decode;
 use serde::Serialize;
+use ssz::Decode;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(start)]
@@ -69,6 +69,70 @@ pub async fn verify_header_with_proof(bytes: Vec<u8>) -> Result<JsValue, JsError
 
     serde_wasm_bindgen::to_value(&out)
         .map_err(|e| JsError::new(&format!("serialization failed: {}", e)))
+}
+
+/// Verify a transaction is in a block at the given index, against an
+/// authenticated `transactionsRoot`.
+///
+/// Inputs:
+/// * `transactionsRoot` — 32-byte authenticated root from a `VerifiedBlock`.
+/// * `txIndex` — position of the transaction in the block.
+/// * `rawTx` — EIP-2718 wire-format bytes (legacy: RLP; typed: type-byte || RLP).
+/// * `proofNodes` — RLP-encoded MPT trie nodes from root down to the leaf,
+///   passed as a JS array of `Uint8Array`.
+///
+/// Throws on verification failure.
+#[wasm_bindgen(js_name = verifyTransactionInclusion)]
+pub fn verify_transaction_inclusion(
+    transactions_root: Vec<u8>,
+    tx_index: u64,
+    raw_tx: Vec<u8>,
+    proof_nodes: js_sys::Array,
+) -> Result<(), JsError> {
+    let root = parse_root(&transactions_root, "transactionsRoot")?;
+    let proof = parse_proof_nodes(&proof_nodes)?;
+    eth_historian::inclusion::verify_transaction_inclusion(root, tx_index, &raw_tx, &proof)
+        .map_err(|e| JsError::new(&format!("verifyTransactionInclusion: {}", e)))
+}
+
+/// Verify a receipt is in a block at the given index, against an
+/// authenticated `receiptsRoot`.
+///
+/// Inputs match [`verifyTransactionInclusion`] except the value is the
+/// receipt's wire-format bytes (legacy: RLP; typed: type-byte || RLP).
+///
+/// Throws on verification failure.
+#[wasm_bindgen(js_name = verifyReceiptInclusion)]
+pub fn verify_receipt_inclusion(
+    receipts_root: Vec<u8>,
+    receipt_index: u64,
+    raw_receipt: Vec<u8>,
+    proof_nodes: js_sys::Array,
+) -> Result<(), JsError> {
+    let root = parse_root(&receipts_root, "receiptsRoot")?;
+    let proof = parse_proof_nodes(&proof_nodes)?;
+    eth_historian::inclusion::verify_receipt_inclusion(root, receipt_index, &raw_receipt, &proof)
+        .map_err(|e| JsError::new(&format!("verifyReceiptInclusion: {}", e)))
+}
+
+fn parse_root(bytes: &[u8], field: &str) -> Result<alloy_primitives::B256, JsError> {
+    if bytes.len() != 32 {
+        return Err(JsError::new(&format!(
+            "{} must be 32 bytes, got {}",
+            field,
+            bytes.len()
+        )));
+    }
+    Ok(alloy_primitives::B256::from_slice(bytes))
+}
+
+fn parse_proof_nodes(array: &js_sys::Array) -> Result<Vec<Vec<u8>>, JsError> {
+    let mut out = Vec::with_capacity(array.length() as usize);
+    for value in array.iter() {
+        let bytes = js_sys::Uint8Array::new(&value).to_vec();
+        out.push(bytes);
+    }
+    Ok(out)
 }
 
 /// Returns the SHA-256 fingerprints of the embedded canonized accumulator


### PR DESCRIPTION
## Summary

Surfaces v0.2's `verify_*_inclusion` Rust API across all three FFI bindings. Off-chain consumers in JS, Python, and Go can now prove specific receipts or transactions are inside an authenticated block with a single library call — completing the v0.2 product story end-to-end.

## API

| Binding | Transaction inclusion | Receipt inclusion |
|---|---|---|
| **TS** | `verifyTransactionInclusion(txRoot, txIndex, rawTx, proofNodes)` | `verifyReceiptInclusion(...)` |
| **Python** | `verify_transaction_inclusion(tx_root, tx_index, raw_tx, proof_nodes)` | `verify_receipt_inclusion(...)` |
| **Go** | `VerifyTransactionInclusion(txRoot, txIndex, rawTx, proofNodes) error` | `VerifyReceiptInclusion(...)` |

* Roots are 32-byte buffers (`Uint8Array` / `bytes` / `[]byte`).
* `proofNodes` is the language-native list-of-byte-arrays type.
* Failure surfaces as `throw` / `ValueError` / `error`.

## C ABI (Go binding)

Two new entry points in `bindings/go/include/eth_historian.h` — both follow the established `NULL on success, malloc'd C string on failure` convention.

## Per-binding LOC

* TS: ~50 LOC FFI shim + README updates
* Python: ~60 LOC FFI shim + `__init__.py` re-exports + README
* Go: ~100 LOC Rust FFI + ~60 LOC cgo wrapper + 3 new tests + C header + README

## Test plan

- [x] **TS** — `cargo build --target wasm32-unknown-unknown` clean. (Binding has no JS-side test infra; behavior is inherited from the Rust-core `tests/inclusion.rs`.)
- [x] **Python** — `cargo check` clean. `cargo build` link-fails *locally* on PyO3 0.24 + Python 3.14 ABI mismatch (local-env issue; CI/maturin wheel builds use 3.13 and work).
- [x] **Go** — `cargo build --release`, `go build`, `go test ./...` all pass. 9 Go tests (was 6); added wrong-root-length rejection + empty-proof rejection.
- [x] Rust core: 64 tests still pass; `cargo fmt --check` clean.

## Common change across all three bindings

Added `alloy-primitives = "1"` as a direct dep in each binding's `Cargo.toml` so the FFI shim can construct `B256` from raw bytes without pulling the full alloy umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)