### PR TITLE
chore: consolidate v0.1.0 release scope + add CI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,211 @@
+name: Release
+
+# Triggered by pushing a tag like `v0.1.0`. Each job is independent —
+# if (e.g.) PyPI publish fails, the crates.io / npm jobs can still succeed
+# and the failed step can be re-run on its own.
+#
+# Required repo secrets:
+#   - CARGO_REGISTRY_TOKEN  (https://crates.io/me, "API Tokens")
+#   - NPM_TOKEN             (npm "Automation" token; needs publish access
+#                            to @willow-network)
+#   - PYPI_API_TOKEN        (PyPI scoped token for the `eth-historian`
+#                            project)
+#
+# The `GITHUB_TOKEN` is provided automatically and is used for the Go
+# release artifact upload (no extra secret needed).
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  # ---------------------------------------------------------------------
+  # Rust core → crates.io
+  # ---------------------------------------------------------------------
+  publish-crates-io:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Verify Cargo.toml version matches the tag
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          manifest_version=$(cargo metadata --format-version=1 --no-deps \
+            | jq -r '.packages[] | select(.name=="eth-historian") | .version')
+          if [ "$tag_version" != "$manifest_version" ]; then
+            echo "::error::tag $GITHUB_REF_NAME (version $tag_version) does not match Cargo.toml version $manifest_version"
+            exit 1
+          fi
+      - name: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+
+  # ---------------------------------------------------------------------
+  # TypeScript binding → npm
+  # ---------------------------------------------------------------------
+  publish-npm:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Verify package.json version matches the tag
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          pkg_version=$(jq -r '.version' bindings/ts/package.json)
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::tag $GITHUB_REF_NAME (version $tag_version) does not match bindings/ts/package.json version $pkg_version"
+            exit 1
+          fi
+      - name: Build wasm bundle
+        working-directory: bindings/ts
+        run: wasm-pack build --target bundler --out-dir pkg --release
+      - name: npm publish
+        working-directory: bindings/ts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
+
+  # ---------------------------------------------------------------------
+  # Python binding → PyPI (matrix builds wheels per-platform/per-version)
+  # ---------------------------------------------------------------------
+  publish-pypi:
+    name: Build wheels (${{ matrix.os }} / py${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: bindings/python
+      - name: Install maturin
+        run: pip install maturin
+      - name: Verify pyproject version matches the tag
+        shell: bash
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          py_version=$(python -c "import tomllib;print(tomllib.load(open('bindings/python/pyproject.toml','rb'))['project']['version'])")
+          if [ "$tag_version" != "$py_version" ]; then
+            echo "::error::tag $GITHUB_REF_NAME (version $tag_version) does not match bindings/python/pyproject.toml version $py_version"
+            exit 1
+          fi
+      - name: Build wheel
+        working-directory: bindings/python
+        run: maturin build --release --strip --out dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: bindings/python/dist/*.whl
+
+  upload-pypi:
+    name: Upload wheels to PyPI
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist-merged
+          merge-multiple: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install twine
+        run: pip install twine
+      - name: twine upload
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload --skip-existing dist-merged/*.whl
+
+  # ---------------------------------------------------------------------
+  # Go binding → GitHub release (per-platform static-lib tarballs).
+  # Go modules are versioned by git tag automatically, so consumers can
+  # already `go get @v0.1.0` after the tag is pushed; this job ships the
+  # pre-built `libeth_historian.a` per platform so Go consumers don't need
+  # cargo locally.
+  # ---------------------------------------------------------------------
+  build-go-static-lib:
+    name: Build static lib (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            artifact: libeth_historian-darwin-arm64.tar.gz
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            artifact: libeth_historian-linux-amd64.tar.gz
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            artifact: libeth_historian-windows-amd64.tar.gz
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: bindings/go
+      - name: cargo build --release (static lib)
+        working-directory: bindings/go
+        run: cargo build --release --target ${{ matrix.target }}
+      - name: Tar up the static lib + C header
+        shell: bash
+        working-directory: bindings/go
+        run: |
+          mkdir -p out
+          cp target/${{ matrix.target }}/release/libeth_historian.a out/ 2>/dev/null \
+            || cp target/${{ matrix.target }}/release/eth_historian.lib out/libeth_historian.a
+          cp include/eth_historian.h out/
+          tar -czf "${{ matrix.artifact }}" -C out .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: bindings/go/${{ matrix.artifact }}
+
+  release-github:
+    name: Create GitHub release + attach Go artifacts
+    needs: build-go-static-lib
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes "Release $GITHUB_REF_NAME — see CHANGELOG.md or commits since previous tag." \
+            artifacts/libeth_historian-*.tar.gz

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -161,7 +161,7 @@ one snapshot in the `HistoricalSummariesProvider` and looks up the
 relevant index for each request. If your application verifies blocks
 across a wide time range, refresh the snapshot when it falls behind.
 
-## Inclusion verification (v0.2+)
+## Inclusion verification
 
 `VerifiedBlock` carries the authenticated `transactions_root` and
 `receipts_root`. The [`inclusion`](../src/inclusion.rs) module turns
@@ -190,7 +190,7 @@ the trie shape we generate matches `alloy::consensus::proofs::calculate_receipt_
 
 * **State roots.** `header.state_root` is authenticated, but resolving
   individual storage slots requires additional MPT proofs out of scope
-  here. (Could land in v0.3 — same pattern as receipt inclusion, but
+  here. (Could land in a future release — same pattern as receipt inclusion, but
   against the state trie which is significantly more complex.)
 * **Reorgs.** This crate authenticates that a block was *at some point*
   canonical (per the embedded accumulator or current beacon state). It

--- a/README.md
+++ b/README.md
@@ -102,9 +102,10 @@ See [`ARCHITECTURE.md`](./ARCHITECTURE.md) for the full trust-model writeup, inc
 
 eth-historian doesn't fetch bytes itself; you plug in one or more `DataSource` impls. Built-ins:
 
-* **`ArchiveRpcSource`** — talks `eth_getBlockByNumber` to any Ethereum execution RPC, then constructs the canonized accumulator proof locally. Pre-merge only (post-merge proof construction is on the v0.2 roadmap).
+* **`ArchiveRpcSource`** — talks `eth_getBlockByNumber` to any Ethereum execution RPC, then constructs the canonized accumulator proof locally. Pre-merge proofs come from a configured `EpochProvider`; post-merge proofs (Bellatrix → Electra) come from a configured [`BeaconDataProvider`](#post-merge-operator-setup).
+* **`BeaconRpcSource`** — talks the standard Ethereum beacon-API to a (typically self-run) archive beacon node. Implements `BeaconDataProvider`. Required for post-merge `ArchiveRpcSource` proof construction.
 * **`PortalSidecarSource`** — talks `portal_legacyHistoryGetContent` to a separately-running `trin` sidecar. Covers all eras trin serves.
-* **`Era1FileSource`** — *scaffold; v0.2 — see [`Cargo.toml`](./Cargo.toml) for why disabled.*
+* **`Era1FileSource`** — *scaffold; tracked as [issue #13](https://github.com/willow-network/eth-historian/issues/13) — unblocked now that ethportal-api is no longer a transitive dep.*
 
 Multi-source fallback works automatically — register sources in priority order and the first one that returns valid bytes wins.
 
@@ -133,9 +134,14 @@ Post-Capella verification has standard sync-committee light-client trust — no 
 
 ## Status
 
-* **v0.1**: Rust core, TS bindings (wasm-bindgen), Python bindings (PyO3), Go bindings (cgo), `ArchiveRpcSource` (pre-merge), `PortalSidecarSource` (all eras).
-* **v0.2** (this release): `inclusion` module — receipt / transaction / log inclusion verification against authenticated roots.
-* **v0.3** (planned): `Era1FileSource`, post-merge proof construction in `ArchiveRpcSource` (closes the trin-sidecar dependency for full era coverage), hosted epoch-accumulator data bundle, Swift bindings.
+**v0.1.0** ships the full inclusion-verification + historical-block-authentication surface across all four post-merge forks:
+
+* **Rust core** — `Verifier`, `inclusion` module (receipt / transaction / log inclusion against authenticated roots), four authentication paths (HistoricalHashes / HistoricalRoots / HistoricalSummaries{Capella,Deneb}).
+* **Bindings** — TypeScript (wasm-bindgen), Python (PyO3), Go (cgo + cdylib).
+* **Data sources** — `ArchiveRpcSource` (full era range, pre-merge via `EpochProvider`, post-merge via `BeaconDataProvider`), `PortalSidecarSource`, `BeaconRpcSource`.
+* **End-to-end Merkle-path validation** against real mainnet `SignedBeaconBlock` fixtures across Bellatrix / Capella / Deneb / Electra.
+
+Filed for follow-ups: [`Era1FileSource`](https://github.com/willow-network/eth-historian/issues/13) re-enable, [HistoricalBatch caching](https://github.com/willow-network/eth-historian/issues/15), [Swift](https://github.com/willow-network/eth-historian/issues/5) and [React Hooks](https://github.com/willow-network/eth-historian/issues/14) bindings, [hosted epoch_accs bundle](https://github.com/willow-network/eth-historian/issues/6).
 
 ## Prior art
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,57 @@
+# Releasing eth-historian
+
+The release workflow at `.github/workflows/release.yml` publishes to four registries on tag push:
+
+| Registry | Package | Source |
+|---|---|---|
+| crates.io | `eth-historian` | `Cargo.toml` |
+| npm | `@willow-network/eth-historian` | `bindings/ts/package.json` |
+| PyPI | `eth-historian` | `bindings/python/pyproject.toml` |
+| GitHub Releases (Go) | per-platform `libeth_historian.a` tarballs | `bindings/go/` |
+
+## One-time setup
+
+Add these GitHub repo secrets (Settings → Secrets and variables → Actions):
+
+* `CARGO_REGISTRY_TOKEN` — from <https://crates.io/me>, "API Tokens"
+* `NPM_TOKEN` — npm "Automation" token with publish access to the `@willow-network` org
+* `PYPI_API_TOKEN` — PyPI scoped token for the `eth-historian` project
+
+`GITHUB_TOKEN` is provided automatically.
+
+## Cutting a release
+
+1. **Bump versions in lockstep** across:
+   * `Cargo.toml` (Rust core)
+   * `bindings/ts/package.json` (TypeScript)
+   * `bindings/python/pyproject.toml` and `bindings/python/Cargo.toml` (Python)
+   * The Go binding inherits the version from the git tag — no file change needed.
+
+   The release workflow checks each manifest's version equals the tag's version (without the `v` prefix) and fails fast if they drift. Keep them aligned.
+
+2. **Push the version-bump commit** to `main` and confirm CI is green.
+
+3. **Tag the release** locally:
+   ```bash
+   git tag v0.1.0
+   git push origin v0.1.0
+   ```
+   This triggers `.github/workflows/release.yml`. Each registry job is independent; if one fails (e.g. PyPI tokens expired), the other three still publish and the failed step can be re-run.
+
+4. **Verify** at:
+   * <https://crates.io/crates/eth-historian>
+   * <https://www.npmjs.com/package/@willow-network/eth-historian>
+   * <https://pypi.org/project/eth-historian/>
+   * <https://github.com/willow-network/eth-historian/releases>
+
+## Go consumers
+
+Go modules are versioned by git tags directly — once `v0.1.0` is pushed, `go get github.com/willow-network/eth-historian/bindings/go@v0.1.0` works.
+
+The release workflow additionally publishes pre-built static libs as GitHub release assets, so Go consumers don't need a local Rust toolchain to build the cgo dep:
+
+* `libeth_historian-darwin-arm64.tar.gz`
+* `libeth_historian-linux-amd64.tar.gz`
+* `libeth_historian-windows-amd64.tar.gz`
+
+Each tarball contains `libeth_historian.a` + `eth_historian.h`. Drop them into `bindings/go/target/release/` (or wherever cgo `LDFLAGS -L` is pointing) and the Go module compiles without cargo.

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -36,8 +36,7 @@ func main() {
 
     // 2. Verify cryptographically against the canonized accumulators.
     //    Pre-merge and merge→Capella work today; post-Capella requires
-    //    extending the binding to accept a HistoricalSummaries snapshot
-    //    (tracked as a v0.2 follow-up).
+    //    extending the binding to accept a HistoricalSummaries snapshot.
     verified, err := eth_historian.VerifyHeaderWithProof(sszBytes)
     if err != nil {
         log.Fatalf("verification failed: %v", err)
@@ -55,7 +54,7 @@ func main() {
 }
 ```
 
-### Inclusion verification (v0.2)
+### Inclusion verification
 
 Once a block is authenticated, prove specific receipts or transactions are inside it via MPT proofs against the verified roots:
 
@@ -85,7 +84,7 @@ The Go module currently builds against a locally-built Rust static library at `t
 * macOS arm64 + linux amd64 + windows amd64 are the typical first three
 * Use `goreleaser` or a GitHub Actions matrix to publish a tarball per platform
 
-This is a v0.2 packaging concern — for v0.1, contributors check out the repo and run `make test`.
+Pre-built distribution is a follow-up packaging task — for v0.1.0, contributors check out the repo and run `make test`.
 
 ## Trust model
 

--- a/bindings/go/include/eth_historian.h
+++ b/bindings/go/include/eth_historian.h
@@ -42,7 +42,7 @@ EthHistorianVerifyResult eth_historian_verify_header_with_proof(
 void eth_historian_free_error(char* error);
 
 /*
- * Inclusion verification (v0.2). Both functions return NULL on success;
+ * Inclusion verification. Both functions return NULL on success;
  * on failure they return a malloc'd C string the caller MUST free via
  * eth_historian_free_error().
  *

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -39,7 +39,7 @@ assert fp["merge_macc_bin_sha256"] == \
     "0xa2368bfa82a89a898b31dca6f37aa287918bd671bd74058912bc440c2288d791"
 ```
 
-### Inclusion verification (v0.2)
+### Inclusion verification
 
 Once a block is authenticated, prove specific receipts or transactions are inside it via MPT proofs against the verified roots:
 

--- a/bindings/ts/README.md
+++ b/bindings/ts/README.md
@@ -35,7 +35,7 @@ console.log(fp.mergeMaccBinSha256);
 //   0xa2368bfa82a89a898b31dca6f37aa287918bd671bd74058912bc440c2288d791
 ```
 
-### Inclusion verification (v0.2)
+### Inclusion verification
 
 Once a block is authenticated, prove specific receipts or transactions are inside it via MPT proofs against the verified roots:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,4 +22,4 @@ Default block is Uniswap V2's deployment (May 4, 2020), which demonstrates the p
 
 ## More examples on the way
 
-`v0.2` will add: archive-RPC + locally-constructed proofs (no Portal sidecar required), Era1 file source, multi-source fallback chain, post-Capella with a fresh `HistoricalSummaries` snapshot pulled from a beacon RPC.
+This release ships the full inclusion-verification + historical-block-authentication surface across all four post-merge forks. See the main repo README for a complete capability list.

--- a/src/sources/era1.rs
+++ b/src/sources/era1.rs
@@ -16,7 +16,7 @@
 //! This source is a scaffold. The actual Era1 parsing depends on the
 //! published `e2store = "0.4"` crate's API surface. The wiring shape is
 //! correct (DataSource impl, file resolution); end-to-end Era1 reading
-//! is on the v0.2 roadmap.
+//! is tracked at https://github.com/willow-network/eth-historian/issues/13.
 
 use std::path::PathBuf;
 
@@ -42,7 +42,7 @@ impl Era1FileSource {
 impl DataSource for Era1FileSource {
     async fn fetch_header_with_proof_by_number(&self, _block_number: u64) -> Result<Vec<u8>> {
         Err(Error::DataSource(format!(
-            "Era1FileSource at {} — Era1 file reading is not yet implemented; tracked for v0.2",
+            "Era1FileSource at {} — Era1 file reading is not yet implemented; see https://github.com/willow-network/eth-historian/issues/13",
             self.root.display()
         )))
     }

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -55,4 +55,5 @@ pub mod beacon_rpc;
 pub use beacon_rpc::{BeaconDataProvider, BeaconRpcSource};
 
 // `era1` feature currently disabled — see `Cargo.toml` for details.
-// The scaffold is preserved at `src/sources/era1.rs` for v0.2.
+// The scaffold is preserved at `src/sources/era1.rs`; tracked at
+// https://github.com/willow-network/eth-historian/issues/13.


### PR DESCRIPTION
## Summary

Two related cleanups in prep for the v0.1.0 release:

1. **Doc consolidation** — strip the v0.1 / v0.2 / v0.3 split that drifted into the READMEs. Nothing has shipped to a registry yet, so the split is internal-only. v0.1.0 now describes the full surface built this session (inclusion + post-merge construction + bindings + end-to-end Merkle-path validation across all four post-merge forks).

2. **CI release workflow** at `.github/workflows/release.yml` triggered on `v*.*.*` tag push. Four independent jobs:
   - `publish-crates-io` — `cargo publish` with `CARGO_REGISTRY_TOKEN`
   - `publish-npm` — `wasm-pack build` + `npm publish` with `NPM_TOKEN`
   - `publish-pypi` (matrix → upload-pypi) — maturin wheels per (ubuntu/macos/windows) × (3.9–3.13), single upload to PyPI with `PYPI_API_TOKEN`
   - `build-go-static-lib` (matrix → release-github) — pre-built `libeth_historian.a` per platform (darwin-arm64, linux-amd64, windows-amd64) attached to a GH release

   Each job verifies the tag matches its respective manifest version and fails fast on drift.

3. **`RELEASING.md`** documents the secrets-setup + tag-push flow.

## What this PR does NOT do

* **No actual publishing.** The workflow only runs on tag push; no tag is being created here. First `v0.1.0` tag will trigger a real publish whenever you're ready (deferred a few days for social-media coordination).
* **No version bumps.** All packages were already at 0.1.0.

## Required repo secrets (one-time setup before the first release)

* `CARGO_REGISTRY_TOKEN` — crates.io API token
* `NPM_TOKEN` — npm Automation token with `@willow-network` org publish access
* `PYPI_API_TOKEN` — PyPI scoped token for `eth-historian`

`GITHUB_TOKEN` is provided automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)